### PR TITLE
Restore compatibility with Foundry v9

### DIFF
--- a/NotYourTurn.js
+++ b/NotYourTurn.js
@@ -4,7 +4,7 @@
  */
 
 import {registerSettings} from "./src/settings.js";
-import {compatibleCore, checkCombat, whisperGM, sockets, disableMoveKeys, storeAllPositions, setTokenPositionOld, setTokenPositionNew, undoMovement} from "./src/misc.js";
+import {checkCombat, whisperGM, sockets, disableMoveKeys, storeAllPositions, setTokenPositionOld, setTokenPositionNew, undoMovement} from "./src/misc.js";
 
 new Date();
 let timer = 0; 
@@ -106,7 +106,7 @@ async function setNonCombat(value){
 Hooks.on('controlToken', (token,controlled)=>{
     if (controlled) {
         
-        token.setFlag('NotYourTurn','location',{x:token.x,y:token.y});
+        token.document.setFlag('NotYourTurn','location',{x:token.x,y:token.y});
         for (let i=0; i<controlledTokens.length; i++)
             if (controlledTokens[i] == token.id)
                 return;
@@ -132,8 +132,8 @@ Hooks.on('controlToken', (token,controlled)=>{
 
 
 Hooks.on('updateToken',(a,b,c,d,e)=>{
-    const updateData = compatibleCore('0.8.6') ? b : c;
-    const userId = compatibleCore('0.8.6') ? d : e;
+    const updateData = b;
+    const userId = d;
 
     //Check if movement has been updated
     if (updateData.x == undefined && updateData.y == undefined) return;
@@ -172,19 +172,19 @@ async function blockMovement(data){
         let token = canvas.tokens.children[0].children.find(p => p.id == controlledTokens[i]);
         let location = {x:token.x+movementShift.x, y:token.y+movementShift.y};
         if (checkCombat() && dialogWait == false && game.settings.get('NotYourTurn','AlwaysBlock') == false){
-            const combatTokenId = compatibleCore('0.8.6') ? game.combat.combatant.token.id : game.combat.combatant.tokenId;
+            const combatTokenId = game.combat.combatant.token.id;
             if (combatTokenId == controlledTokens[i]){ 
-                await token.setFlag('NotYourTurn','location',location);
+                await token.document.setFlag('NotYourTurn','location',location);
                 continue;
             }
-            let isCombatant = compatibleCore('0.8.6') ? game.combat.combatants.find(p => p.token.id == controlledTokens[i]) : game.combat.combatants.find(p => p.tokenId == controlledTokens[i]);
+            let isCombatant = game.combat.combatants.find(p => p.token.id == controlledTokens[i]);
             if (isCombatant == undefined && game.settings.get('NotYourTurn','nonCombat') == false){
-                await token.setFlag('NotYourTurn','location',location);
+                await token.document.setFlag('NotYourTurn','location',location);
                 continue;
             }
         }
         const tokenName = token.name;
-        tokens[counter] = {id: controlledTokens[i], name: tokenName, location, locationOld: token.getFlag('NotYourTurn','location')};
+        tokens[counter] = {id: controlledTokens[i], name: tokenName, location, locationOld: token.document.getFlag('NotYourTurn','location')};
         counter++;
     }
 
@@ -299,7 +299,7 @@ async function blockMovement(data){
                     dialogWait = false;
                 }  
                 else if (applyChanges == 2) { //request movement
-                    const users = compatibleCore('0.8.6') ? game.users.contents : game.users.entries;
+                    const users = game.users.contents;
                     //Request movement from GM, then apply movement (GM can undo this)   
                     for (let i=0; i<game.data.users.length; i++)
                         if (users[i].role > 2) {

--- a/module.json
+++ b/module.json
@@ -2,12 +2,12 @@
     "name": "NotYourTurn",
     "title": "Not Your Turn!",
     "description": "Block token movement if it's not the token's turn.",
-    "version": "1.1.5",
+    "version": "1.2.0",
     "author": "CDeenen",
     "esmodules": ["./NotYourTurn.js"],
     "socket": true,
-    "minimumCoreVersion": "0.6.6",
-    "compatibleCoreVersion": "0.8.6",
+    "minimumCoreVersion": "9.0",
+    "compatibleCoreVersion": "9.0",
     "languages": [
       {
         "lang": "en",

--- a/src/misc.js
+++ b/src/misc.js
@@ -1,15 +1,5 @@
 import {duplicateCheck,setDuplicateCheck,setDialogWait,setGMwait,setTimer} from "../NotYourTurn.js";
 
-export function compatibleCore(compatibleVersion){
-    let coreVersion = game.data.version;
-    coreVersion = coreVersion.split(".");
-    compatibleVersion = compatibleVersion.split(".");
-    if (compatibleVersion[0] > coreVersion[0]) return false;
-    if (compatibleVersion[1] > coreVersion[1]) return false;
-    if (compatibleVersion[2] > coreVersion[2]) return false;
-    return true;
-  }
-
 export function checkCombat(){
     if (game.combat) 
         return game.combat.started;
@@ -31,7 +21,7 @@ export async function storeAllPositions(){
     for (let i=0; i<tokens.length; i++){
         let token = tokens[i];
         let position = tokens[i]._validPosition;
-        await token.setFlag('NotYourTurn','location',position);
+        await token.document.setFlag('NotYourTurn','location',position);
     }
 }
 
@@ -39,8 +29,8 @@ export async function setTokenPositionOld(tokens){
     for (let i=0; i<tokens.length; i++){
         let token = canvas.tokens.children[0].children.find(p => p.id == tokens[i].id);
         let position = tokens[i].locationOld;
-        await token.update(position);
-        await token.setFlag('NotYourTurn','location',position);
+        await token.document.update(position);
+        await token.document.setFlag('NotYourTurn','location',position);
     }
 }
 
@@ -48,8 +38,8 @@ export async function setTokenPositionNew(tokens){
     for (let i=0; i<tokens.length; i++){
         let token = canvas.tokens.children[0].children.find(p => p.id == tokens[i].id);
         let position = tokens[i].location;
-        await token.update(position);
-        await token.setFlag('NotYourTurn','location',position);
+        await token.document.update(position);
+        await token.document.setFlag('NotYourTurn','location',position);
     }
 }
 


### PR DESCRIPTION
Quickfix to restore functionality of Not your turn in Foundry v9 due to API changes.
Removes little code for checks if version higher then actual (was 0.8.6) and earlier foundry versions and limited this in module.json by requieredCoreVersion tag.
Increased version number of module to 1.2.0 from 1.1.5.

Resolves #20 

Original git commit note:
Restore compatibility with Foundry v9
Remove module internal compatibility checks and set to minimum core v9 in module.json

