### PR TITLE
Remove out of date fields from module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,6 +1,5 @@
 {
     "id": "NotYourTurn",
-    "name": "NotYourTurn",
     "title": "Not Your Turn!",
     "description": "Block token movement if it's not the token's turn.",
     "version": "2.3.0",
@@ -12,7 +11,6 @@
     }],
     "esmodules": ["./NotYourTurn.js"],
     "socket": true,
-    "minimumCoreVersion": 10,
     "compatibility": {
       "minimum": "13",
       "verified": "13",


### PR DESCRIPTION
Attempt to fix:

The "Not Your Turn!" module's manifest contained the following unknown keys: "name", "minimumCoreVersion"